### PR TITLE
Add output for version without v-prefix to bump-semver-tag #minor

### DIFF
--- a/.github/workflows/post-issue-to-card.yml
+++ b/.github/workflows/post-issue-to-card.yml
@@ -9,6 +9,6 @@ jobs:
     name: Post issue to card
     runs-on: ubuntu-latest
     steps:
-      - uses: ./post-issue-to-card
+      - uses: svvsaga/github-actions-public/post-issue-to-card@v3.8.2
         with:
           apikey: ${{ secrets.KANBANIZE_API_KEY }}

--- a/bump-semver-tag/action.yml
+++ b/bump-semver-tag/action.yml
@@ -14,3 +14,5 @@ inputs:
 outputs:
   tag:
     description: The new tag, or empty string if no tag was created.
+  version:
+    description: The new version (tag without v-prefix), or empty string if no version was incremented.

--- a/bump-semver-tag/index.js
+++ b/bump-semver-tag/index.js
@@ -52,6 +52,7 @@ function bumpSemverTag() {
                 throw new Error(`Failed to tag ${nextTag}`);
             }
             core.setOutput('tag', nextTag);
+            core.setOutput('version', nextTag.substring(1));
         }
         else {
             core.info(`No tags found, or no #patch, #minor or #major commit msgs`);

--- a/src/bump-semver-tag-implementation.ts
+++ b/src/bump-semver-tag-implementation.ts
@@ -16,6 +16,7 @@ export async function bumpSemverTag(): Promise<void> {
       throw new Error(`Failed to tag ${nextTag}`)
     }
     core.setOutput('tag', nextTag)
+    core.setOutput('version', nextTag.substring(1))
   } else {
     core.info(`No tags found, or no #patch, #minor or #major commit msgs`)
   }


### PR DESCRIPTION
Useful when passing the version to e.g. Gradle for publishing packages
