### PR TITLE
Add reusable workflow for running all Gradle integration tests in repository

### DIFF
--- a/.github/workflows/run-all-gradle-integration-tests-and-report-to-slack.yml
+++ b/.github/workflows/run-all-gradle-integration-tests-and-report-to-slack.yml
@@ -1,0 +1,101 @@
+name: Run all Gradle integration tests and report errors to Slack channel
+
+on:
+  workflow_call:
+    inputs:
+      ignore_modules_regex:
+        description: Regex of modules to ignore, e.g. 'utils/.*'.
+        type: string
+        required: false
+        default: ""
+      ignore_modules:
+        description: Comma-separated list of relative paths to ignore. Must include dot at start of relative path, e.g. `., ./system/alpha`.
+        type: string
+        required: false
+        default: ""
+
+    secrets:
+      slack_webhook_url:
+        description: A Slack Webhook URL for posting to a Slack channel
+        required: true
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  REF: ${{ github.inputs.ref }}
+
+jobs:
+  find-modules:
+    name: Find gradle modules
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Find gradle modules
+        id: find-gradle-modules
+        uses: svvsaga/github-actions-public/find-gradle-module-changes@v7.0.0
+        with:
+          include_all: true
+          ignore_modules_regex: ${{ inputs.ignore_modules_regex }}
+          ignore_modules: ${{ inputs.ignore_modules }}
+    outputs:
+      matrix: ${{ steps.find-gradle-modules.outputs.matrix }}
+      has_results: ${{ steps.find-gradle-modules.outputs.has_results }}
+
+  run-integration-tests:
+    name: Run integration tests
+    runs-on: ubuntu-latest
+    needs: find-modules
+    if: needs.find-modules.outputs.has_results == 'true'
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJson(needs.find-modules.outputs.matrix) }}
+    defaults:
+      run:
+        working-directory: ${{ matrix.path }}
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Cache Gradle
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Read integration testing config
+        id: read-integration-testing-config
+        uses: svvsaga/github-actions-public/read-integration-testing-config@v7.0.0
+        with:
+          cwd: ${{ matrix.path }}
+
+      - name: Setup Google Cloud SDK with workload identity federation
+        uses: svvsaga/github-actions-public/setup-gcloud-with-workload-identity@v5.0.6
+        with:
+          service_account: ${{ steps.read-integration-testing-config.outputs.service_account }}
+          project_id: ${{ steps.read-integration-testing-config.outputs.workload_identity_project_id }}
+          project_number: ${{ steps.read-integration-testing-config.outputs.workload_identity_project_number }}
+
+      - name: Gradle build and integration test
+        id: build-and-inttest
+        continue-on-error: true
+        run: ./gradlew inttest
+
+      - name: Send integration test errors to Slack channel
+        uses: slackapi/slack-github-action@v1.17.0
+        if: steps.build-and-inttest.outcome == 'failure'
+        env:
+            SLACK_WEBHOOK_URL: ${{ secrets.slack_webhook_url }}
+        with:
+          payload: |
+            {
+              "project_name": "${{ matrix.folder }}",
+              "github_run_url": "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            }


### PR DESCRIPTION
KB-8469: add reusable workflow for running all Gradle integration tests in repository

**Checklist**

- [x] Are there any major, minor or patch changes in here? If so, have you remembered to add a hashtag \#major, \#minor or \#patch in any of the commit msgs?
