### PR TITLE
Change method call after braking change

### DIFF
--- a/show-terraform-plan-on-pr/action.yml
+++ b/show-terraform-plan-on-pr/action.yml
@@ -166,7 +166,7 @@ runs:
 
           *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`*`;
 
-          github.issues.createComment({
+          github.rest.issues.createComment({
             issue_number: context.issue.number,
             owner: context.repo.owner,
             repo: context.repo.repo,


### PR DESCRIPTION
All octokit methods that were available on github has been moved to github.rest as of v5 of github-script ref: https://github.com/actions/github-script#breaking-changes-in-v5
