### PR TITLE
Refactor depricated set-output #patch

### DIFF
--- a/publish-terraform-plan-as-artifact/action.yml
+++ b/publish-terraform-plan-as-artifact/action.yml
@@ -106,7 +106,11 @@ runs:
       id: set-has-changes
       working-directory: ${{ inputs.terraform_dir }}
       shell: bash
-      run: grep -q "No changes. Your infrastructure matches the configuration." "${{ env.PLAN_TXT_FILENAME }}" && echo "::set-output name=has_changes::0" && echo "No changes found." || echo "::set-output name=has_changes::1" && echo "Changes found."
+      run: |
+        grep -q "No changes. Your infrastructure matches the configuration." "${{ env.PLAN_TXT_FILENAME }}" 
+        && echo "has_changes=0" >> $GITHUB_OUTPUT
+        && echo "No changes found." || echo "has_changes=1" >> $GITHUB_OUTPUT
+        && echo "Changes found."
 
     - name: Upload plan
       uses: actions/upload-artifact@v2


### PR DESCRIPTION
The set-output command is depricated and will be removed. Use new command. ref: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
