### PR TITLE
Set required timeout_minutes to please nick fields retry action #patch

### DIFF
--- a/.github/workflows/run-all-gradle-integration-tests-and-report-to-slack.yml
+++ b/.github/workflows/run-all-gradle-integration-tests-and-report-to-slack.yml
@@ -91,6 +91,7 @@ jobs:
         with:
           command: ${{ inputs.build_and_inttest_cmd }}
           retry_wait_seconds: 60
+          timeout_minutes: 10
           max_attempts: 3
 
       - name: Send integration test errors to Slack channel


### PR DESCRIPTION
An attempt to fix

> Error: Must specify either timeout_minutes or timeout_seconds inputs

https://github.com/svvsaga/saga/actions/runs/3511303636/jobs/5881948698#step:6:24

10 minutes is a little more than a usual "run all integration tests nightly" run.

**Checklist**

- [x] Are there any major, minor or patch changes in here? If so, have you remembered to add a hashtag \#major, \#minor or \#patch in any of the commit msgs?
