### PR TITLE
Attempt to fix retry action not accepting cwd #patch

### DIFF
--- a/.github/workflows/run-all-gradle-integration-tests-and-report-to-slack.yml
+++ b/.github/workflows/run-all-gradle-integration-tests-and-report-to-slack.yml
@@ -89,7 +89,7 @@ jobs:
         continue-on-error: true
         uses: nick-fields/retry@3e91a01664abd3c5cd539100d10d33b9c5b68482
         with:
-          command: ${{ inputs.build_and_inttest_cmd }}
+          command: cd ${{ matrix.path }} && ${{ inputs.build_and_inttest_cmd }}
           retry_wait_seconds: 60
           timeout_minutes: 10
           max_attempts: 3


### PR DESCRIPTION
KB-11776

Attempt to fix

```
bash: ./gradlew: No such file or directory
Warning: Attempt 1 failed. Reason: Child_process exited with error code 127
```

https://github.com/svvsaga/saga/actions/runs/3512329488/jobs/5883930745#step:6:30

**Checklist**

- [x] Are there any major, minor or patch changes in here? If so, have you remembered to add a hashtag \#major, \#minor or \#patch in any of the commit msgs?
