### PR TITLE
Add TF_VAR_ENV to two composite workflows

### DIFF
--- a/apply-terraform-plan-from-artifact/action.yml
+++ b/apply-terraform-plan-from-artifact/action.yml
@@ -13,7 +13,7 @@ inputs:
     description: Service account key for the Terraform service account. Use either this or Workload Identity Federation.
     required: false
   environment:
-    description: STM, ATM, PROD or SHARED. Used to setup Workload Identity Federation. Must be set if service_account_key is not set.
+    description: STM, ATM, PROD or SHARED. Used to setup Terragrunt and Workload Identity Federation. Must be set if service_account_key is not set.
     required: false
   github_token:
     description: Token used when authenticating with GitHub. Defaults to `github.token`.
@@ -82,6 +82,8 @@ runs:
     - name: Terragrunt init
       if: ${{ steps.check-plan.outputs.exists == 'true' }}
       working-directory: ${{ inputs.terraform_dir }}
+      env:
+        TF_VAR_ENV: ${{ inputs.environment }}
       shell: bash
       run: test -z "${{ inputs.tf_backend_config }}" && terragrunt init -reconfigure || terragrunt init -reconfigure -backend-config=${{ inputs.tf_backend_config }}
 

--- a/publish-terraform-plan-as-artifact/action.yml
+++ b/publish-terraform-plan-as-artifact/action.yml
@@ -75,6 +75,8 @@ runs:
 
     - name: Terragrunt init
       working-directory: ${{ inputs.terraform_dir }}
+      env:
+        TF_VAR_ENV: ${{ inputs.environment }}
       shell: bash
       run: test -z "${{ inputs.tf_backend_config }}" && terragrunt init -reconfigure || terragrunt init -reconfigure -backend-config=${{ inputs.tf_backend_config }}
 


### PR DESCRIPTION
We use TF_VAR_ENV quite a lot. Two workflows did not support it.

**Checklist**

- [x] Are there any major, minor or patch changes in here? If so, have you remembered to add a hashtag \#major, \#minor or \#patch in any of the commit msgs?
